### PR TITLE
feat: allow generating mock data with customizable options (gender, b…

### DIFF
--- a/src/fakerData.ts
+++ b/src/fakerData.ts
@@ -2,14 +2,34 @@ import { faker } from '@faker-js/faker';
 import religions from './data/thaiReligions.json';
 import provincesData from './data/thaiProvinces.json';
 
-function generateBirthDate(): string {
-  return faker.date.birthdate({ min: 18, max: 75, mode: 'age' }).toISOString().split('T')[0];
+function generateBirthDate(year?: number): string {
+  const y = year ?? faker.date.past().getFullYear();
+  const m = faker.date.month({ abbreviated: false });
+  const d = faker.number.int({ min: 1, max: 28 });
+  return `${y}-${m}-${d}`;
 }
+
 
 function calculateAge(birthDate: string): number {
   const birth = new Date(birthDate);
   return Math.floor((new Date().getTime() - birth.getTime()) / (1000 * 3600 * 24 * 365));
 }
+
+export const defaultOptions: Partial<GenerateOptions> = {
+  gender: undefined,
+  bornYear: undefined,
+  religion: undefined,
+  seed: undefined
+};
+
+
+export interface GenerateOptions {
+  gender: 'ชาย' | 'หญิง';
+  bornYear: number;
+  religion: string;
+  seed: number;
+}
+
 
 function generateThaiID(): string {
   const idNumber = [...Array(12)].map(() => Math.floor(Math.random() * 10));
@@ -18,13 +38,18 @@ function generateThaiID(): string {
   return idNumber.join('');
 }
 
-export function generateMockPerson() {
-  const gender = faker.helpers.arrayElement(['ชาย', 'หญิง']);
+export function generateMockPerson(options?: Partial<GenerateOptions>) {
+  if (options?.seed !== undefined) {
+    faker.seed(options.seed);
+  }
+  const gender = options?.gender ?? faker.helpers.arrayElement(['ชาย', 'หญิง']);
   const firstName = faker.person.firstName(gender === 'ชาย' ? 'male' : 'female');
   const lastName = faker.person.lastName();
-  const birthDate = generateBirthDate();
+  const birthDate = options?.bornYear
+    ? generateBirthDate(options.bornYear)
+    : generateBirthDate();
   const age = calculateAge(birthDate);
-  const religion = faker.helpers.arrayElement(religions);
+  const religion = options?.religion ?? faker.helpers.arrayElement(religions);
 
   const randomProvince = faker.helpers.arrayElement(provincesData);
   const province = randomProvince.province;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,21 @@
-import { generateMockPerson } from './fakerData';
+import { generateMockPerson, GenerateOptions } from './fakerData';
 import { exportToJson, exportToCsv } from './exporter';
 
-export function generatePeople(count: number) {
-  return Array.from({ length: count }, () => generateMockPerson());
+export function generateThaiID(options?: Partial<GenerateOptions>) {
+  return generateMockPerson(options);
 }
 
-export function exportPeople(count: number) {
-  const people = generatePeople(count);
+export function generatePeople(count: number, options?: Partial<GenerateOptions>) {
+  return Array.from({ length: count }, (_, i) =>
+    generateMockPerson({
+      ...options,
+      seed: options?.seed !== undefined ? options.seed + i : undefined,
+    })
+  );
+}
+
+export function exportPeople(count: number, options?: Partial<GenerateOptions>) {
+  const people = generatePeople(count, options);
 
   const fs = require('fs');
   fs.mkdirSync('output', { recursive: true });


### PR DESCRIPTION
### Add support for customizable options when generating mock data

### ✨ What’s new?
This PR adds support for passing custom options to the `generateMockPerson` and `generatePeople` functions, allowing users to define:
- `gender`: male or female
- `bornYear`: a specific birth year
- `religion`: custom or predefined values
- `seed`: to make generation deterministic

### 🔧 Changes
- Updated `fakerData.ts` to accept and apply `Partial<GenerateOptions>`
- Added `GenerateOptions` interface
- Enhanced `generatePeople` to increment `seed` for each person
- Updated `index.ts` to support option-passing across export/generate functions

### ✅ Benefits
- Better control and repeatability for testing or sample datasets
- More realistic and targeted mock data generation

---

Let me know if we should also allow specifying province or age range in the next update!
